### PR TITLE
fix: correct typo 'recieve' → 'receive' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ GOOGLE_APPLICATION_CREDENTIALS - Your GCP Credentials get from Google Cloud
 
 ```vars.txt
 STRIPE_TOKEN - Stripe.com token for receiving Donations.
-SLACK_TOKEN - slack.com api token to recieve Feedbacks on Slack.com if not entered you will recieve in your Telegram 
+SLACK_TOKEN - slack.com api token to receive Feedbacks on Slack.com if not entered you will receive in your Telegram 
 ```
 
 ## Where To Get The Optional Vars...


### PR DESCRIPTION
## Description

Fixed a typo in README.md: corrected "recieve" to "receive" (appeared twice on line 58).

### Changes
- `README.md`: Fixed spelling error in the SLACK_TOKEN description

### Before
> SLACK_TOKEN - slack.com api token to **recieve** Feedbacks on Slack.com if not entered you will **recieve** in your Telegram

### After
> SLACK_TOKEN - slack.com api token to **receive** Feedbacks on Slack.com if not entered you will **receive** in your Telegram

---

This is a simple documentation fix. No functional changes.